### PR TITLE
Implement ERAM datablock drawing scaffolding

### DIFF
--- a/pkg/panes/eram/datablock.go
+++ b/pkg/panes/eram/datablock.go
@@ -1,3 +1,311 @@
 package eram
 
+import (
+	"strings"
+
+	av "github.com/mmp/vice/pkg/aviation"
+	"github.com/mmp/vice/pkg/math"
+	"github.com/mmp/vice/pkg/panes"
+	"github.com/mmp/vice/pkg/radar"
+	"github.com/mmp/vice/pkg/renderer"
+	"github.com/mmp/vice/pkg/sim"
+)
+
+// DatablockType enumerates the supported ERAM datablock formats. Only the
+// general types are provided here; the specific contents are defined
+// elsewhere.
 type DatablockType int
+
+const (
+	// LimitedDatablock represents the two-line limited data block used for
+	// untracked or unpaired targets.
+	LimitedDatablock DatablockType = iota
+	// FullDatablock represents the five line full data block.
+	FullDatablock
+	// EnhancedLimitedDatablock represents the optional enhanced limited data
+	// block.  It behaves like LimitedDatablock with additional information.
+	EnhancedLimitedDatablock
+)
+
+// datablock abstracts the different concrete datablock implementations.  A
+// datablock knows how to render itself at a particular point relative to the
+// leader line.
+type datablock interface {
+	draw(td *renderer.TextDrawBuilder, pt [2]float32, font *renderer.Font,
+		sb *strings.Builder, brightness radar.ScopeBrightness,
+		dir math.CardinalOrdinalDirection, halfSeconds int64)
+}
+
+// dbChar represents a single character in a datablock along with its colour and
+// flashing state.
+type dbChar struct {
+	ch       rune
+	color    renderer.RGB
+	flashing bool
+}
+
+// --- Drawing helpers -----------------------------------------------------
+
+// dbLine stores characters making up a single line of a datablock.  The slice
+// length is capped to the maximum possible number of characters drawn on a
+// line.
+type dbLine struct {
+	length int
+	ch     [16]dbChar
+}
+
+// dbMakeLine flattens a number of datablock fields into a contiguous line.
+func dbMakeLine(fields ...[]dbChar) dbLine {
+	var l dbLine
+	for _, f := range fields {
+		for _, ch := range f {
+			l.ch[l.length] = ch
+			l.length++
+		}
+	}
+	return l
+}
+
+// Len returns the number of active characters in the line.
+func (l dbLine) Len() int {
+	for i := l.length - 1; i >= 0; i-- {
+		if l.ch[i].ch != 0 {
+			return i + 1
+		}
+	}
+	return 0
+}
+
+// dbChopTrailing removes trailing unset characters from the provided field.
+func dbChopTrailing(f []dbChar) []dbChar {
+	for i := len(f) - 1; i >= 0; i-- {
+		if f[i].ch != 0 {
+			return f[:i+1]
+		}
+	}
+	return nil
+}
+
+// dbDrawLines renders the given datablock lines.  The leader line direction is
+// used only to determine justification.
+func dbDrawLines(lines []dbLine, td *renderer.TextDrawBuilder, pt [2]float32,
+	font *renderer.Font, sb *strings.Builder, brightness radar.ScopeBrightness,
+	dir math.CardinalOrdinalDirection, halfSeconds int64) {
+
+	rightJustify := dir >= math.South
+	glyph := font.LookupGlyph(' ')
+	fontWidth := glyph.AdvanceX
+
+	for _, line := range lines {
+		xOffset := float32(4)
+		if rightJustify {
+			xOffset = -4 - float32(line.Len())*fontWidth
+		}
+		sb.Reset()
+		dbDrawLine(line, td, math.Add2f(pt, [2]float32{xOffset, 0}), font, sb,
+			brightness, halfSeconds)
+		pt[1] -= float32(font.Size)
+	}
+}
+
+// dbDrawLine renders a single datablock line.
+func dbDrawLine(line dbLine, td *renderer.TextDrawBuilder, pt [2]float32,
+	font *renderer.Font, sb *strings.Builder, brightness radar.ScopeBrightness,
+	halfSeconds int64) {
+
+	style := renderer.TextStyle{Font: font}
+
+	flush := func() {
+		if sb.Len() > 0 {
+			pt = td.AddText(rewriteDelta(sb.String()), pt, style)
+			sb.Reset()
+		}
+	}
+
+	for i := 0; i < line.length; i++ {
+		ch := line.ch[i]
+		if ch.ch == 0 {
+			sb.WriteByte(' ')
+			continue
+		}
+
+		br := brightness
+		if ch.flashing && halfSeconds&1 == 1 {
+			br /= 3
+		}
+
+		c := br.ScaleRGB(ch.color)
+		if !c.Equals(style.Color) {
+			flush()
+			style.Color = c
+		}
+		sb.WriteRune(ch.ch)
+	}
+	flush()
+}
+
+// fieldEmpty reports whether the datablock field contains any characters.
+func fieldEmpty(f []dbChar) bool {
+	for _, ch := range f {
+		if ch.ch != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// rewriteDelta is a stub used by dbDrawLine.  ERAM uses standard fonts so no
+// rewriting is required.
+func rewriteDelta(s string) string { return s }
+
+///////////////////////////////////////////////////////////////////////////
+// Concrete datablock types
+
+// limitedDatablock holds the characters for a limited data block.  The exact
+// field layout is intentionally omitted; callers populate the character arrays
+// as appropriate.
+type limitedDatablock struct {
+	line0 [8]dbChar
+	line1 [8]dbChar
+	line2 [8]dbChar
+}
+
+func (db limitedDatablock) draw(td *renderer.TextDrawBuilder, pt [2]float32,
+	font *renderer.Font, sb *strings.Builder, brightness radar.ScopeBrightness,
+	dir math.CardinalOrdinalDirection, halfSeconds int64) {
+
+	lines := []dbLine{
+		dbMakeLine(dbChopTrailing(db.line0[:])),
+		dbMakeLine(dbChopTrailing(db.line1[:])),
+		dbMakeLine(dbChopTrailing(db.line2[:])),
+	}
+	pt[1] += float32(font.Size)
+	dbDrawLines(lines, td, pt, font, sb, brightness, dir, halfSeconds)
+}
+
+// fullDatablock is used for the five line ERAM FDB.  As with limitedDatablock
+// the exact field definitions are not specified here.
+type fullDatablock struct {
+	line0 [16]dbChar
+	line1 [16]dbChar
+	line2 [16]dbChar
+	line3 [16]dbChar
+	line4 [16]dbChar
+}
+
+func (db fullDatablock) draw(td *renderer.TextDrawBuilder, pt [2]float32,
+	font *renderer.Font, sb *strings.Builder, brightness radar.ScopeBrightness,
+	dir math.CardinalOrdinalDirection, halfSeconds int64) {
+
+	lines := []dbLine{
+		dbMakeLine(dbChopTrailing(db.line0[:])),
+		dbMakeLine(dbChopTrailing(db.line1[:])),
+		dbMakeLine(dbChopTrailing(db.line2[:])),
+		dbMakeLine(dbChopTrailing(db.line3[:])),
+		dbMakeLine(dbChopTrailing(db.line4[:])),
+	}
+	pt[1] += float32(font.Size)
+	dbDrawLines(lines, td, pt, font, sb, brightness, dir, halfSeconds)
+}
+
+///////////////////////////////////////////////////////////////////////////
+// High-level datablock helpers
+
+// getAllDatablocks creates datablocks for the given tracks using the pane's
+// object arenas. The caller is responsible for ensuring ep.TrackState has been
+// initialized for each track.
+func (ep *ERAMPane) getAllDatablocks(ctx *panes.Context, tracks []sim.Track) map[av.ADSBCallsign]datablock {
+	ep.fdbArena.Reset()
+	ep.ldbArena.Reset()
+
+	dbs := make(map[av.ADSBCallsign]datablock)
+	for _, trk := range tracks {
+		state := ep.TrackState[trk.ADSBCallsign]
+		if state == nil {
+			continue
+		}
+
+		color := renderer.RGB{}
+		brightness := radar.ScopeBrightness(0)
+		if state.DatablockType == FullDatablock {
+			brightness = ep.currentPrefs().Brightness.FDB
+		} else {
+			brightness = ep.currentPrefs().Brightness.LDB
+		}
+		dbs[trk.ADSBCallsign] = ep.getDatablock(ctx, trk, color, brightness)
+	}
+	return dbs
+}
+
+// getDatablock returns a datablock object for the given track. No datablock
+// fields are populated here; callers are expected to do so elsewhere.
+func (ep *ERAMPane) getDatablock(ctx *panes.Context, trk sim.Track, color renderer.RGB,
+	brightness radar.ScopeBrightness) datablock {
+	state := ep.TrackState[trk.ADSBCallsign]
+	if state == nil {
+		return nil
+	}
+
+	switch state.DatablockType {
+	case FullDatablock:
+		return ep.fdbArena.AllocClear()
+	case LimitedDatablock, EnhancedLimitedDatablock:
+		return ep.ldbArena.AllocClear()
+	default:
+		return nil
+	}
+}
+
+// drawDatablocks draws the given map of datablocks. The map should have been
+// created by getAllDatablocks. Leader lines and datablock characters are drawn
+// using default fonts and colours.
+func (ep *ERAMPane) drawDatablocks(tracks []sim.Track, dbs map[av.ADSBCallsign]datablock,
+	ctx *panes.Context, transforms radar.ScopeTransformations, cb *renderer.CommandBuffer) {
+	td := renderer.GetTextDrawBuilder()
+	defer renderer.ReturnTextDrawBuilder(td)
+
+	var ldbs, eldbs, fdbs []sim.Track
+	for _, trk := range tracks {
+		if !ep.datablockVisible(ctx, trk) {
+			continue
+		}
+		switch ep.datablockType(ctx, trk) {
+		case FullDatablock:
+			fdbs = append(fdbs, trk)
+		case EnhancedLimitedDatablock:
+			eldbs = append(eldbs, trk)
+		default:
+			ldbs = append(ldbs, trk)
+		}
+	}
+
+	font := renderer.GetDefaultFont()
+	var sb strings.Builder
+	halfSeconds := ctx.Now.UnixMilli() / 500
+
+	draw := func(tracks []sim.Track) {
+		for _, trk := range tracks {
+			db := dbs[trk.ADSBCallsign]
+			if db == nil {
+				continue
+			}
+			state := ep.TrackState[trk.ADSBCallsign]
+			if state == nil {
+				continue
+			}
+
+			start := transforms.WindowFromLatLongP(state.track.Location)
+			dir := ep.leaderLineDirection(ctx, trk)
+			end := math.Add2f(start, math.Scale2f(ep.leaderLineVector(dir), ctx.DrawPixelScale))
+			brightness := ep.datablockBrightness(state)
+			db.draw(td, end, font, &sb, brightness, dir, halfSeconds)
+		}
+	}
+
+	for _, set := range [][]sim.Track{ldbs, eldbs, fdbs} {
+		draw(set)
+	}
+
+	transforms.LoadWindowViewingMatrices(cb)
+	td.GenerateCommands(cb)
+}

--- a/pkg/panes/eram/eram.go
+++ b/pkg/panes/eram/eram.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mmp/vice/pkg/radar"
 	"github.com/mmp/vice/pkg/renderer"
 	"github.com/mmp/vice/pkg/sim"
+	"github.com/mmp/vice/pkg/util"
 )
 
 var (
@@ -26,9 +27,14 @@ var (
 type ERAMPane struct {
 	ERAMPreferenceSets map[string]*PrefrenceSet
 	prefSet            *PrefrenceSet
-	TrackState map[av.ADSBCallsign]*TrackState
+	TrackState         map[av.ADSBCallsign]*TrackState
 
 	allVideoMaps []sim.VideoMap
+
+	// Pools of datablocks used while rendering. Keeping arenas here avoids
+	// allocations every frame when the datablocks are generated.
+	fdbArena util.ObjectArena[fullDatablock]
+	ldbArena util.ObjectArena[limitedDatablock]
 
 	InboundPointOuts  map[string]string
 	OutboundPointOuts map[string]string

--- a/pkg/panes/eram/track.go
+++ b/pkg/panes/eram/track.go
@@ -162,11 +162,11 @@ func (ep *ERAMPane) drawTrack(track sim.Track, state *TrackState, ctx *panes.Con
 	ld *renderer.ColoredLinesDrawBuilder, trid *renderer.ColoredTrianglesDrawBuilder, td *renderer.TextDrawBuilder) {
 	pos := state.track.Location
 	pw := transforms.WindowFromLatLongP(pos)
-	pt := math.Add2f(pw, [2]float32{0.5, -.5}) // Text this out 
+	pt := math.Add2f(pw, [2]float32{0.5, -.5}) // Text this out
 
-	// Draw the position symbol 
+	// Draw the position symbol
 	color := ep.trackColor(state, track)
-	font := renderer.GetDefaultFont() // Change this to the actual font 
+	font := renderer.GetDefaultFont() // Change this to the actual font
 	td.AddTextCentered(position, pt, renderer.TextStyle{Font: font, Color: color})
 }
 
@@ -178,12 +178,86 @@ func (ep *ERAMPane) trackColor(state *TrackState, track sim.Track) renderer.RGB 
 	return color
 }
 
-func (ep *ERAMPane) visibleTracks(ctx *panes.Context) []sim.Track { // When radar holes are added 
+func (ep *ERAMPane) visibleTracks(ctx *panes.Context) []sim.Track { // When radar holes are added
 	// Get the visible tracks based on the current range and center.
 	var tracks []sim.Track
 	for _, trk := range ctx.Client.State.Tracks {
 		// Radar wholes neeeded for this. For now, return true
 		tracks = append(tracks, *trk)
 	}
-	return tracks 
+	return tracks
+}
+
+// datablockBrightness returns the configured brightness for the given track's
+// datablock type.
+func (ep *ERAMPane) datablockBrightness(state *TrackState) radar.ScopeBrightness {
+	ps := ep.currentPrefs()
+	if state.DatablockType == FullDatablock {
+		return ps.Brightness.FDB
+	}
+	return ps.Brightness.LDB
+}
+
+// leaderLineDirection returns the direction in which a datablock's leader line
+// should be drawn. The initial implementation always points northeast.
+func (ep *ERAMPane) leaderLineDirection(ctx *panes.Context, trk sim.Track) math.CardinalOrdinalDirection {
+	return math.NorthEast
+}
+
+// leaderLineVector returns a vector in window coordinates representing a leader
+// line of a fixed length in the given direction.
+func (ep *ERAMPane) leaderLineVector(dir math.CardinalOrdinalDirection) [2]float32 {
+	angle := dir.Heading()
+	v := [2]float32{math.Sin(math.Radians(angle)), math.Cos(math.Radians(angle))}
+	return math.Scale2f(v, 32)
+}
+
+// datablockVisible reports whether a datablock should be drawn. Design.
+func (ep *ERAMPane) datablockVisible(ctx *panes.Context, trk sim.Track) bool {
+	// design
+	return true
+}
+
+// datablockType chooses which datablock format to display. Design.
+func (ep *ERAMPane) datablockType(ctx *panes.Context, trk sim.Track) DatablockType {
+	// design
+	return LimitedDatablock
+}
+
+// trackDatablockColorBrightness returns the track color and datablock brightness. Design.
+func (ep *ERAMPane) trackDatablockColorBrightness(ctx *panes.Context, trk sim.Track) (renderer.RGB, radar.ScopeBrightness, radar.ScopeBrightness) {
+	// design
+	return renderer.RGB{}, 0, 0
+}
+
+// drawLeaderLines draws leader lines for visible datablocks.
+func (ep *ERAMPane) drawLeaderLines(ctx *panes.Context, tracks []sim.Track, dbs map[av.ADSBCallsign]datablock,
+	transforms radar.ScopeTransformations, cb *renderer.CommandBuffer) {
+	ld := renderer.GetColoredLinesDrawBuilder()
+	defer renderer.ReturnColoredLinesDrawBuilder(ld)
+
+	for _, trk := range tracks {
+		if dbs[trk.ADSBCallsign] == nil {
+			continue
+		}
+
+		_, brightness, _ := ep.trackDatablockColorBrightness(ctx, trk)
+		if brightness == 0 {
+			continue
+		}
+
+		state := ep.TrackState[trk.ADSBCallsign]
+		if state == nil {
+			continue
+		}
+		p0 := transforms.WindowFromLatLongP(state.track.Location)
+		dir := ep.leaderLineDirection(ctx, trk)
+		v := ep.leaderLineVector(dir)
+		p1 := math.Add2f(p0, math.Scale2f(v, ctx.DrawPixelScale))
+		ld.AddLine(p0, p1, brightness.ScaleRGB(renderer.RGB{R: 1, G: 1, B: 1}))
+	}
+
+	transforms.LoadWindowViewingMatrices(cb)
+	cb.LineWidth(1, ctx.DPIScale)
+	ld.GenerateCommands(cb)
 }


### PR DESCRIPTION
## Summary
- add helper functions for datablock creation and rendering
- include leader line helpers and brightness selection in track state
- refine drawing helpers and add design placeholders for ERAM datablocks

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6854a9b30368832a860fac70218d3a2b