### PR TITLE
Add CID to flight plan and reuse after deletion

### DIFF
--- a/pkg/sim/aircraft.go
+++ b/pkg/sim/aircraft.go
@@ -26,6 +26,9 @@ type Aircraft struct {
 	// callsigns; however, the ADS-B callsign is transmitted from the
 	// aircraft and would be the same to all facilities.
 	ADSBCallsign av.ADSBCallsign
+	// CID is a three character code assigned to the aircraft when it
+	// spawns in the simulation.
+	CID string
 
 	Squawk av.Squawk
 	Mode   av.TransponderMode

--- a/pkg/sim/cid.go
+++ b/pkg/sim/cid.go
@@ -1,0 +1,109 @@
+package sim
+
+import "fmt"
+
+var preferredAlphas = []rune{'P', 'K', 'N', 'Y', 'T', 'V', 'F', 'R', 'C', 'D', 'E', 'W', 'A'}
+var nonPreferredAlphas = []rune{'M', 'X', 'L', 'J', 'U', 'B', 'G', 'Q', 'S', 'H', 'Z'}
+
+// CIDAllocator manages allocation of unique three-character CIDs.
+type CIDAllocator struct {
+	available []string
+	allocated map[string]struct{}
+}
+
+func NewCIDAllocator() *CIDAllocator {
+	return &CIDAllocator{
+		available: generateCIDList(),
+		allocated: make(map[string]struct{}),
+	}
+}
+
+// Allocate returns the next available CID.
+func (c *CIDAllocator) Allocate() (string, error) {
+	if len(c.available) == 0 {
+		return "", fmt.Errorf("no more CIDs available")
+	}
+	cid := c.available[0]
+	c.available = c.available[1:]
+	c.allocated[cid] = struct{}{}
+	return cid, nil
+}
+
+// Release frees a CID so it can be reused.
+func (c *CIDAllocator) Release(cid string) {
+	if _, ok := c.allocated[cid]; ok {
+		delete(c.allocated, cid)
+		c.available = append([]string{cid}, c.available...)
+	}
+}
+
+func generateCIDList() []string {
+	digits := []rune{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'}
+	var codes []string
+	add := func(r1, r2, r3 rune) { codes = append(codes, string([]rune{r1, r2, r3})) }
+	// 1. ddd
+	for _, a := range digits {
+		for _, b := range digits {
+			for _, c := range digits {
+				add(a, b, c)
+			}
+		}
+	}
+	// 2. dda_p
+	for _, a := range digits {
+		for _, b := range digits {
+			for _, l := range preferredAlphas {
+				add(a, b, l)
+			}
+		}
+	}
+	// 3. da_p a_p
+	for _, a := range digits {
+		for _, l1 := range preferredAlphas {
+			for _, l2 := range preferredAlphas {
+				add(a, l1, l2)
+			}
+		}
+	}
+	// 4. da_p d
+	for _, a := range digits {
+		for _, l := range preferredAlphas {
+			for _, b := range digits {
+				add(a, l, b)
+			}
+		}
+	}
+	// 5. dda_n
+	for _, a := range digits {
+		for _, b := range digits {
+			for _, l := range nonPreferredAlphas {
+				add(a, b, l)
+			}
+		}
+	}
+	// 6. da_n a_n, da_n a_p, da_p a_n
+	for _, d := range digits {
+		for _, a1 := range nonPreferredAlphas {
+			for _, a2 := range nonPreferredAlphas {
+				add(d, a1, a2)
+			}
+			for _, a2 := range preferredAlphas {
+				add(d, a1, a2)
+			}
+		}
+		for _, a1 := range preferredAlphas {
+			for _, a2 := range nonPreferredAlphas {
+				add(d, a1, a2)
+			}
+		}
+	}
+	// 7. da_n d
+	for _, a := range digits {
+		for _, l := range nonPreferredAlphas {
+			for _, b := range digits {
+				add(a, l, b)
+			}
+		}
+	}
+	return codes
+}

--- a/pkg/sim/control.go
+++ b/pkg/sim/control.go
@@ -183,6 +183,14 @@ func (s *Sim) DeleteAircraft(tcp string, callsign av.ADSBCallsign) error {
 }
 
 func (s *Sim) deleteAircraft(ac *Aircraft) {
+	if ac.CID != "" && s.CIDAllocator != nil {
+		s.CIDAllocator.Release(ac.CID)
+		if ac.STARSFlightPlan != nil {
+			ac.STARSFlightPlan.CID = ""
+		} else if fp := s.STARSComputer.lookupFlightPlanByACID(ACID(ac.ADSBCallsign)); fp != nil {
+			fp.CID = ""
+		}
+	}
 	delete(s.Aircraft, ac.ADSBCallsign)
 
 	s.STARSComputer.HoldForRelease = slices.DeleteFunc(s.STARSComputer.HoldForRelease,

--- a/pkg/sim/sim.go
+++ b/pkg/sim/sim.go
@@ -43,6 +43,7 @@ type Sim struct {
 	ERAMComputer  *ERAMComputer
 
 	LocalCodePool *av.LocalSquawkCodePool
+	CIDAllocator  *CIDAllocator
 
 	GenerationIndex int // for sequencing StateUpdates
 
@@ -199,6 +200,8 @@ func NewSim(config NewSimConfiguration, manifest *VideoMapManifest, lg *log.Logg
 		SignOnPositions: config.SignOnPositions,
 
 		STARSComputer: makeSTARSComputer(config.TRACON),
+
+		CIDAllocator: NewCIDAllocator(),
 
 		LocalCodePool: av.MakeLocalSquawkCodePool(config.STARSFacilityAdaptation.SSRCodes),
 
@@ -1543,6 +1546,9 @@ func (ac *Aircraft) IsAssociated() bool {
 
 func (ac *Aircraft) AssociateFlightPlan(fp *STARSFlightPlan) {
 	fp.Location = math.Point2LL{} // clear location in case it was an unsupported DB
+	if ac.CID != "" {
+		fp.CID = ac.CID
+	}
 	ac.STARSFlightPlan = fp
 	ac.PreArrivalDropController = ""
 }

--- a/pkg/sim/spawn.go
+++ b/pkg/sim/spawn.go
@@ -336,6 +336,20 @@ func (s *Sim) addAircraftNoLock(ac Aircraft) {
 		return
 	}
 
+	if ac.CID == "" && s.CIDAllocator != nil {
+		if cid, err := s.CIDAllocator.Allocate(); err == nil {
+			ac.CID = cid
+			if ac.STARSFlightPlan != nil {
+				ac.STARSFlightPlan.CID = cid
+			} else if fp := s.STARSComputer.lookupFlightPlanByACID(ACID(ac.ADSBCallsign)); fp != nil {
+				fp.CID = cid
+				ac.STARSFlightPlan = fp
+			}
+		} else {
+			s.lg.Warn("no CID available", slog.String("callsign", string(ac.ADSBCallsign)))
+		}
+	}
+
 	s.Aircraft[ac.ADSBCallsign] = &ac
 
 	ac.Nav.Check(s.lg)

--- a/pkg/sim/stars.go
+++ b/pkg/sim/stars.go
@@ -402,6 +402,7 @@ type AirspaceAwareness struct {
 
 type STARSFlightPlan struct {
 	ACID                  ACID
+	CID                   string
 	EntryFix              string
 	ExitFix               string
 	ExitFixIsIntermediate bool
@@ -423,11 +424,11 @@ type STARSFlightPlan struct {
 	TypeOfFlight av.TypeOfFlight
 
 	AssignedAltitude      int
-	InterimAlt int 
-	InterimType int 
-	AltitudeBlock [2]int
+	InterimAlt            int
+	InterimType           int
+	AltitudeBlock         [2]int
 	ControllerReportedAlt int
-	VFROTP bool 
+	VFROTP                bool
 
 	RequestedAltitude     int
 	PilotReportedAltitude int


### PR DESCRIPTION
## Summary
- track the three-character CID directly in `STARSFlightPlan`
- allocate a CID when aircraft spawn and copy it to the flight plan
- clear and recycle the CID when the aircraft is removed

## Testing
- `go test ./...` *(fails: Forbidden)*
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68558ed37488832a916d1a572598fd91