### PR TITLE
Implement ERAM track history display

### DIFF
--- a/pkg/panes/eram/eram.go
+++ b/pkg/panes/eram/eram.go
@@ -142,6 +142,7 @@ func (ep *ERAMPane) Draw(ctx *panes.Context, cb *renderer.CommandBuffer) {
 	scopeExtent = ep.drawtoolbar(ctx, transforms, cb)
 	cb.SetScissorBounds(scopeExtend, ctx.Platform.FramebufferSize()[1]/ctx.Platform.DisplaySize()[1])
 	// Draw history
+	ep.drawHistoryTracks(ctx, tracks, transforms, cb)
 	dbs := ep.getAllDatablocks(ctx, tracks)
 	ep.drawLeaderLines(ctx, tracks, dbs, transforms, cb)
 	ep.drawPTLs(ctx, tracks, transforms, cb)

--- a/pkg/panes/eram/eram.go
+++ b/pkg/panes/eram/eram.go
@@ -141,7 +141,6 @@ func (ep *ERAMPane) Draw(ctx *panes.Context, cb *renderer.CommandBuffer) {
 	// draw dcb
 	scopeExtent = ep.drawtoolbar(ctx, transforms, cb)
 	cb.SetScissorBounds(scopeExtend, ctx.Platform.FramebufferSize()[1]/ctx.Platform.DisplaySize()[1])
-	// Draw history
 	ep.drawHistoryTracks(ctx, tracks, transforms, cb)
 	dbs := ep.getAllDatablocks(ctx, tracks)
 	ep.drawLeaderLines(ctx, tracks, dbs, transforms, cb)

--- a/pkg/panes/eram/track.go
+++ b/pkg/panes/eram/track.go
@@ -396,18 +396,28 @@ func (ep *ERAMPane) drawHistoryTracks(ctx *panes.Context, tracks []sim.Track,
 		}
 		color := bright.ScaleRGB(renderer.RGB{.855, .855, 0})
 
-		for i := 0; i < len(state.historyTracks); i++ {
-			idx := (state.historyTrackIndex - 1 - i) % len(state.historyTracks)
-			if idx < 0 {
-				idx += len(state.historyTracks)
-			}
-			loc := state.historyTracks[idx].Location
+		// for i := 0; i < len(state.historyTracks); i++ {
+		// 	idx := (state.historyTrackIndex - 1 - i) % len(state.historyTracks)
+		// 	if idx < 0 {
+		// 		idx += len(state.historyTracks)
+		// 	}
+		// 	loc := state.historyTracks[idx].Location
+		// 	if loc.IsZero() {
+		// 		continue
+		// 	}
+		// 	pw := transforms.WindowFromLatLongP(loc)
+		// 	pt := math.Add2f(pw, [2]float32{0.5, -.5})
+		// 	td.AddTextCentered(symbol, pt, renderer.TextStyle{Font: renderer.GetDefaultFont(), Color: color})
+		// }
+		for _, trk := range state.historyTracks {
+			loc := trk.Location
 			if loc.IsZero() {
 				continue
 			}
 			pw := transforms.WindowFromLatLongP(loc)
 			pt := math.Add2f(pw, [2]float32{0.5, -.5})
 			td.AddTextCentered(symbol, pt, renderer.TextStyle{Font: renderer.GetDefaultFont(), Color: color})
+
 		}
 	}
 


### PR DESCRIPTION
## Summary
- maintain ring-buffer of prior track positions
- reuse position symbol logic via new `positionSymbol` helper
- draw history tracks using PRHST/UNPHST brightness
- call history drawing from ERAM pane

## Testing
- `go vet ./...` *(fails: Forbidden)*
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68577d9c7bf0832aad5e723fac1ec524