### PR TITLE
Add randomized CID allocator

### DIFF
--- a/pkg/sim/cid.go
+++ b/pkg/sim/cid.go
@@ -1,0 +1,153 @@
+package sim
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+)
+
+var preferredAlphas = []rune{'P', 'K', 'N', 'Y', 'T', 'V', 'F', 'R', 'C', 'D', 'E', 'W', 'A'}
+var nonPreferredAlphas = []rune{'M', 'X', 'L', 'J', 'U', 'B', 'G', 'Q', 'S', 'H', 'Z'}
+
+// CIDAllocator manages allocation of unique three-character CIDs.
+type CIDAllocator struct {
+	groups     []map[string]interface{}
+	cidGroup   map[string]int
+	groupIndex int
+	allocated  map[string]struct{}
+	rand       *rand.Rand
+}
+
+func NewCIDAllocator() *CIDAllocator {
+	gs, cm := generateCIDGroups()
+	return &CIDAllocator{
+		groups:    gs,
+		cidGroup:  cm,
+		allocated: make(map[string]struct{}),
+		rand:      rand.New(rand.NewSource(time.Now().UnixNano())),
+	}
+}
+
+// Allocate returns the next available CID.
+func (c *CIDAllocator) Allocate() (string, error) {
+	for c.groupIndex < len(c.groups) {
+		g := c.groups[c.groupIndex]
+		if len(g) == 0 {
+			c.groupIndex++
+			continue
+		}
+		n := c.rand.Intn(len(g))
+		var cid string
+		i := 0
+		for k := range g {
+			if i == n {
+				cid = k
+				break
+			}
+			i++
+		}
+		delete(g, cid)
+		c.allocated[cid] = struct{}{}
+		return cid, nil
+	}
+	return "", fmt.Errorf("no more CIDs available")
+}
+
+// Release frees a CID so it can be reused.
+func (c *CIDAllocator) Release(cid string) {
+	if _, ok := c.allocated[cid]; !ok {
+		return
+	}
+	delete(c.allocated, cid)
+	idx, ok := c.cidGroup[cid]
+	if !ok {
+		return
+	}
+	if c.groups[idx] == nil {
+		c.groups[idx] = make(map[string]interface{})
+	}
+	c.groups[idx][cid] = nil
+	if idx < c.groupIndex {
+		c.groupIndex = idx
+	}
+}
+
+func generateCIDGroups() ([]map[string]interface{}, map[string]int) {
+	digits := []rune{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'}
+	groups := make([]map[string]interface{}, 7)
+	cidMap := make(map[string]int)
+	add := func(idx int, r1, r2, r3 rune) {
+		if groups[idx] == nil {
+			groups[idx] = make(map[string]interface{})
+		}
+		s := string([]rune{r1, r2, r3})
+		groups[idx][s] = nil
+		cidMap[s] = idx
+	}
+
+	for _, a := range digits {
+		for _, b := range digits {
+			for _, c := range digits {
+				add(0, a, b, c)
+			}
+		}
+	}
+
+	for _, a := range digits {
+		for _, b := range digits {
+			for _, l := range preferredAlphas {
+				add(1, a, b, l)
+			}
+		}
+	}
+
+	for _, a := range digits {
+		for _, l1 := range preferredAlphas {
+			for _, l2 := range preferredAlphas {
+				add(2, a, l1, l2)
+			}
+		}
+	}
+
+	for _, a := range digits {
+		for _, l := range preferredAlphas {
+			for _, b := range digits {
+				add(3, a, l, b)
+			}
+		}
+	}
+
+	for _, a := range digits {
+		for _, b := range digits {
+			for _, l := range nonPreferredAlphas {
+				add(4, a, b, l)
+			}
+		}
+	}
+
+	for _, d := range digits {
+		for _, a1 := range nonPreferredAlphas {
+			for _, a2 := range nonPreferredAlphas {
+				add(5, d, a1, a2)
+			}
+			for _, a2 := range preferredAlphas {
+				add(5, d, a1, a2)
+			}
+		}
+		for _, a1 := range preferredAlphas {
+			for _, a2 := range nonPreferredAlphas {
+				add(5, d, a1, a2)
+			}
+		}
+	}
+
+	for _, a := range digits {
+		for _, l := range nonPreferredAlphas {
+			for _, b := range digits {
+				add(6, a, l, b)
+			}
+		}
+	}
+
+	return groups, cidMap
+}

--- a/pkg/sim/control.go
+++ b/pkg/sim/control.go
@@ -183,6 +183,15 @@ func (s *Sim) DeleteAircraft(tcp string, callsign av.ADSBCallsign) error {
 }
 
 func (s *Sim) deleteAircraft(ac *Aircraft) {
+	if s.CIDAllocator != nil {
+		if fp := ac.STARSFlightPlan; fp != nil && fp.CID != "" {
+			s.CIDAllocator.Release(fp.CID)
+			fp.CID = ""
+		} else if fp := s.STARSComputer.lookupFlightPlanByACID(ACID(ac.ADSBCallsign)); fp != nil && fp.CID != "" {
+			s.CIDAllocator.Release(fp.CID)
+			fp.CID = ""
+		}
+	}
 	delete(s.Aircraft, ac.ADSBCallsign)
 
 	s.STARSComputer.HoldForRelease = slices.DeleteFunc(s.STARSComputer.HoldForRelease,

--- a/pkg/sim/sim.go
+++ b/pkg/sim/sim.go
@@ -43,6 +43,7 @@ type Sim struct {
 	ERAMComputer  *ERAMComputer
 
 	LocalCodePool *av.LocalSquawkCodePool
+	CIDAllocator  *CIDAllocator
 
 	GenerationIndex int // for sequencing StateUpdates
 
@@ -199,6 +200,8 @@ func NewSim(config NewSimConfiguration, manifest *VideoMapManifest, lg *log.Logg
 		SignOnPositions: config.SignOnPositions,
 
 		STARSComputer: makeSTARSComputer(config.TRACON),
+
+		CIDAllocator: NewCIDAllocator(),
 
 		LocalCodePool: av.MakeLocalSquawkCodePool(config.STARSFacilityAdaptation.SSRCodes),
 

--- a/pkg/sim/spawn.go
+++ b/pkg/sim/spawn.go
@@ -336,6 +336,21 @@ func (s *Sim) addAircraftNoLock(ac Aircraft) {
 		return
 	}
 
+	if s.CIDAllocator != nil {
+		fp := ac.STARSFlightPlan
+		if fp == nil {
+			fp = s.STARSComputer.lookupFlightPlanByACID(ACID(ac.ADSBCallsign))
+		}
+		if fp != nil && fp.CID == "" {
+			if cid, err := s.CIDAllocator.Allocate(); err == nil {
+				fp.CID = cid
+				ac.STARSFlightPlan = fp
+			} else {
+				s.lg.Warn("no CID available", slog.String("callsign", string(ac.ADSBCallsign)))
+			}
+		}
+	}
+
 	s.Aircraft[ac.ADSBCallsign] = &ac
 
 	ac.Nav.Check(s.lg)

--- a/pkg/sim/stars.go
+++ b/pkg/sim/stars.go
@@ -402,6 +402,7 @@ type AirspaceAwareness struct {
 
 type STARSFlightPlan struct {
 	ACID                  ACID
+	CID                   string
 	EntryFix              string
 	ExitFix               string
 	ExitFixIsIntermediate bool
@@ -423,11 +424,11 @@ type STARSFlightPlan struct {
 	TypeOfFlight av.TypeOfFlight
 
 	AssignedAltitude      int
-	InterimAlt int 
-	InterimType int 
-	AltitudeBlock [2]int
+	InterimAlt            int
+	InterimType           int
+	AltitudeBlock         [2]int
 	ControllerReportedAlt int
-	VFROTP bool 
+	VFROTP                bool
 
 	RequestedAltitude     int
 	PilotReportedAltitude int


### PR DESCRIPTION
## Summary
- update `CIDAllocator` to use maps per format group
- allocate CIDs randomly within a group while honoring format order
- recycle CIDs back into their original groups when aircraft are deleted

## Testing
- `go test ./...` *(fails: Forbidden)*
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68558ed37488832a916d1a572598fd91