### PR TITLE
Fix ERAM glyph lookup and track update delay

### DIFF
--- a/pkg/panes/eram/fonts.go
+++ b/pkg/panes/eram/fonts.go
@@ -19,7 +19,6 @@ func (ep *ERAMPane) ERAMToolbarFont() *renderer.Font {
 	return renderer.GetFont(renderer.FontIdentifier{Name: "ERAMv102", Size: 10})
 }
 
-
 func (ep *ERAMPane) initializeFonts(r renderer.Renderer, p platform.Platform) {
 	fonts := createFontAtlas(r, p)
 	get := func(name string, size int) *renderer.Font {
@@ -73,6 +72,16 @@ func createFontAtlas(r renderer.Renderer, p platform.Platform) []*renderer.Font 
 			glyph.addToFont(ch, x, y, xres, yres, sf, f, scale)
 
 			x += dx
+		}
+
+		// Ensure placeholders exist for all ASCII glyphs so LookupGlyph
+		// never falls back to imgui when using bitmap fonts.
+		space := f.LookupGlyph(' ')
+		placeholder := &renderer.Glyph{AdvanceX: space.AdvanceX, Visible: false}
+		for i := 0; i < len(f.lowGlyphs); i++ {
+			if f.lowGlyphs[i] == nil {
+				f.AddGlyph(i, placeholder)
+			}
 		}
 
 		// Start a new line after finishing a font.

--- a/pkg/panes/eram/track.go
+++ b/pkg/panes/eram/track.go
@@ -35,7 +35,7 @@ type TrackState struct {
 	DisplayJRing        bool
 	DisplayReducedJRing bool
 
-	DisplayVCI bool 
+	DisplayVCI bool
 
 	OSectorEndTime time.Time
 
@@ -115,14 +115,14 @@ func (ep *ERAMPane) processEvents(ctx *panes.Context) {
 		switch event.Type {
 		case sim.AcceptedHandoffEvent:
 			state := ep.TrackState[av.ADSBCallsign(event.ACID)]
-			state.eFDB = true 
+			state.eFDB = true
 			state.OSectorEndTime = ctx.Client.CurrentTime().Add(30 * time.Second) // check this pls
 		case sim.FixCoordinatesEvent:
 			ac := event.ACID
 			coords := event.WaypointInfo
 			ep.aircraftFixCoordinates[string(ac)] = aircraftFixCoordinates{
 				coords:     coords,
-				deleteTime: ctx.Client.CurrentTime().Add(15 * time.Second), // check this time also 
+				deleteTime: ctx.Client.CurrentTime().Add(15 * time.Second), // check this time also
 			}
 		}
 	}
@@ -134,6 +134,9 @@ func (ep *ERAMPane) updateRadarTracks(ctx *panes.Context, tracks []sim.Track) {
 	if now.Sub(ep.dbLastAlternateTime) > 6*time.Second {
 		ep.dbAlternate = !ep.dbAlternate
 		ep.dbLastAlternateTime = now
+	}
+	if len(tracks) == 0 {
+		return
 	}
 	if now.Sub(ep.lastTrackUpdate) < 12*time.Second {
 		return

--- a/pkg/renderer/font.go
+++ b/pkg/renderer/font.go
@@ -102,20 +102,27 @@ func (f *Font) AddGlyph(ch int, g *Glyph) {
 // LookupGlyph returns the Glyph for the specified rune.
 func (f *Font) LookupGlyph(ch rune) *Glyph {
 	if int(ch) < len(f.lowGlyphs) {
-		if g := f.lowGlyphs[ch]; g == nil {
-			g = f.createGlyph(ch)
-			f.lowGlyphs[ch] = g
-			return g
-		} else {
+		if g := f.lowGlyphs[ch]; g != nil {
 			return g
 		}
-	} else if g, ok := f.glyphs[ch]; !ok {
-		g = f.createGlyph(ch)
-		f.glyphs[ch] = g
-		return g
-	} else {
+	} else if g, ok := f.glyphs[ch]; ok {
 		return g
 	}
+
+	// All glyphs should be present for bitmap fonts. If the underlying
+	// ImGui font is unset, return an invisible placeholder rather than
+	// asking imgui to generate one (which would yield an empty glyph).
+	if f.Ifont == (imgui.Font{}) {
+		return &Glyph{}
+	}
+
+	g := f.createGlyph(ch)
+	if int(ch) < len(f.lowGlyphs) {
+		f.lowGlyphs[ch] = g
+	} else {
+		f.glyphs[ch] = g
+	}
+	return g
 }
 
 // Returns the bound of the specified text in the given font, assuming the


### PR DESCRIPTION
## Summary
- avoid imgui fallback when ERAM bitmap fonts miss a glyph
- add placeholder glyphs so LookupGlyph always succeeds
- prevent ERAM track updater from resetting its timer when no tracks are visible

## Testing
- `go test ./...` *(fails: forbidden downloads)*

------
https://chatgpt.com/codex/tasks/task_e_685a0b8a5a08832a9e21b7551746d38c