### PR TITLE
Add multi-controller settings GUI

### DIFF
--- a/pkg/client/control.go
+++ b/pkg/client/control.go
@@ -23,6 +23,18 @@ func (c *ControlClient) TakeOrReturnLaunchControl(eventStream *sim.EventStream) 
 		}))
 }
 
+func (c *ControlClient) TakeOrReturnFlowControl(eventStream *sim.EventStream) {
+	c.addCall(makeRPCCall(c.client.Go("Sim.TakeOrReturnFlowControl", c.controllerToken, nil, nil),
+		func(err error) {
+			if err != nil {
+				eventStream.Post(sim.Event{
+					Type:        sim.StatusMessageEvent,
+					WrittenText: err.Error(),
+				})
+			}
+		}))
+}
+
 func (c *ControlClient) LaunchDeparture(ac sim.Aircraft, rwy string) {
 	c.addCall(makeRPCCall(c.client.Go("Sim.LaunchAircraft", &server.LaunchAircraftArgs{
 		ControllerToken: c.controllerToken,

--- a/pkg/client/control.go
+++ b/pkg/client/control.go
@@ -360,6 +360,19 @@ func (c *ControlClient) SetLaunchConfig(lc sim.LaunchConfig) {
 	c.State.LaunchConfig = lc
 }
 
+func (c *ControlClient) SetMultiControllers(mc av.SplitConfiguration) {
+	c.addCall(makeRPCCall(c.client.Go("Sim.SetMultiControllers",
+		&server.SetMultiControllersArgs{
+			ControllerToken: c.controllerToken,
+			Config:          mc,
+		}, nil, nil), nil))
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.State.MultiControllers = mc
+}
+
 func (c *ControlClient) DeleteAllAircraft(callback func(err error)) {
 	var update sim.StateUpdate
 	c.addCall(makeStateUpdateRPCCall(c.client.Go("Sim.DeleteAllAircraft", &server.DeleteAircraftArgs{

--- a/pkg/renderer/font.go
+++ b/pkg/renderer/font.go
@@ -180,6 +180,7 @@ var (
 	FontAwesomeIconRedo                = faUsedIcons["Redo"]
 	FontAwesomeIconSquare              = faUsedIcons["Square"]
 	FontAwesomeIconTrash               = faUsedIcons["Trash"]
+	FontAwesomeIconUsers               = faUsedIcons["Users"]
 )
 
 var (
@@ -221,6 +222,7 @@ var (
 		"Redo":                FontAwesomeString("Redo"),
 		"Square":              FontAwesomeString("Square"),
 		"Trash":               FontAwesomeString("Trash"),
+		"Users":               FontAwesomeString("Users"),
 	}
 	faBrandsUsedIcons map[string]string = map[string]string{
 		"Discord": FontAwesomeBrandsString("Discord"),

--- a/pkg/server/dispatcher.go
+++ b/pkg/server/dispatcher.go
@@ -90,6 +90,21 @@ func (sd *dispatcher) SetLaunchConfig(lc *SetLaunchConfigArgs, _ *struct{}) erro
 	}
 }
 
+type SetMultiControllersArgs struct {
+	ControllerToken string
+	Config          av.SplitConfiguration
+}
+
+func (sd *dispatcher) SetMultiControllers(mc *SetMultiControllersArgs, _ *struct{}) error {
+	defer sd.sm.lg.CatchAndReportCrash()
+
+	if ctrl, s, ok := sd.sm.LookupController(mc.ControllerToken); !ok {
+		return ErrNoSimForControllerToken
+	} else {
+		return s.SetMultiControllers(ctrl.tcp, mc.Config)
+	}
+}
+
 func (sd *dispatcher) TogglePause(token string, _ *struct{}) error {
 	defer sd.sm.lg.CatchAndReportCrash()
 

--- a/pkg/server/dispatcher.go
+++ b/pkg/server/dispatcher.go
@@ -105,6 +105,16 @@ func (sd *dispatcher) SetMultiControllers(mc *SetMultiControllersArgs, _ *struct
 	}
 }
 
+func (sd *dispatcher) TakeOrReturnFlowControl(token string, _ *struct{}) error {
+	defer sd.sm.lg.CatchAndReportCrash()
+
+	if ctrl, s, ok := sd.sm.LookupController(token); !ok {
+		return ErrNoSimForControllerToken
+	} else {
+		return s.TakeOrReturnFlowControl(ctrl.tcp)
+	}
+}
+
 func (sd *dispatcher) TogglePause(token string, _ *struct{}) error {
 	defer sd.sm.lg.CatchAndReportCrash()
 

--- a/pkg/server/errors.go
+++ b/pkg/server/errors.go
@@ -65,6 +65,7 @@ var errorStringToError = map[string]error{
 	sim.ErrNotClearedForApproach.Error():        sim.ErrNotClearedForApproach,
 	sim.ErrNotFlyingRoute.Error():               sim.ErrNotFlyingRoute,
 	sim.ErrNotLaunchController.Error():          sim.ErrNotLaunchController,
+	sim.ErrNotFlowController.Error():            sim.ErrNotFlowController,
 	sim.ErrTooManyRestrictionAreas.Error():      sim.ErrTooManyRestrictionAreas,
 	sim.ErrTrackIsActive.Error():                sim.ErrTrackIsActive,
 	sim.ErrTrackIsBeingHandedOff.Error():        sim.ErrTrackIsBeingHandedOff,

--- a/pkg/sim/errors.go
+++ b/pkg/sim/errors.go
@@ -34,6 +34,7 @@ var (
 	ErrNotClearedForApproach           = errors.New("Aircraft has not been cleared for an approach")
 	ErrNotFlyingRoute                  = errors.New("Aircraft is not currently flying its assigned route")
 	ErrNotLaunchController             = errors.New("Not signed in as the launch controller")
+	ErrNotFlowController               = errors.New("Not signed in as the flow controller")
 	ErrTooManyRestrictionAreas         = errors.New("Too many restriction areas specified")
 	ErrTrackIsActive                   = errors.New("Track is already active")
 	ErrTrackIsBeingHandedOff           = errors.New("Track is currently being handed off")

--- a/pkg/sim/sim.go
+++ b/pkg/sim/sim.go
@@ -483,6 +483,14 @@ func (s *Sim) SetSimRate(tcp string, rate float32) error {
 	return nil
 }
 
+func (s *Sim) SetMultiControllers(tcp string, mc av.SplitConfiguration) error {
+	s.mu.Lock(s.lg)
+	defer s.mu.Unlock(s.lg)
+
+	s.State.MultiControllers = mc
+	return nil
+}
+
 func (s *Sim) GlobalMessage(tcp, message string) error {
 	s.mu.Lock(s.lg)
 	defer s.mu.Unlock(s.lg)

--- a/pkg/sim/state.go
+++ b/pkg/sim/state.go
@@ -50,10 +50,11 @@ type State struct {
 	Controllers      map[string]*av.Controller
 	HumanControllers []string
 
-	PrimaryController string
-	MultiControllers  av.SplitConfiguration
-	UserTCP           string
-	Airspace          map[string]map[string][]av.ControllerAirspaceVolume // ctrl id -> vol name -> definition
+	PrimaryController          string
+	MultiControllers           av.SplitConfiguration
+	MultiControllersController string
+	UserTCP                    string
+	Airspace                   map[string]map[string][]av.ControllerAirspaceVolume // ctrl id -> vol name -> definition
 
 	GenerationIndex int
 
@@ -115,10 +116,11 @@ func newState(config NewSimConfiguration, manifest *VideoMapManifest, lg *log.Lo
 		Fixes:      config.Fixes,
 		VFRRunways: make(map[string]av.Runway),
 
-		Controllers:       make(map[string]*av.Controller),
-		PrimaryController: config.PrimaryController,
-		MultiControllers:  config.MultiControllers,
-		UserTCP:           serverCallsign,
+		Controllers:                make(map[string]*av.Controller),
+		PrimaryController:          config.PrimaryController,
+		MultiControllers:           config.MultiControllers,
+		MultiControllersController: "",
+		UserTCP:                    serverCallsign,
 
 		DepartureRunways: config.DepartureRunways,
 		ArrivalRunways:   config.ArrivalRunways,

--- a/ui.go
+++ b/ui.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"time"
 
+	av "github.com/mmp/vice/pkg/aviation"
+
 	"github.com/mmp/vice/pkg/client"
 	"github.com/mmp/vice/pkg/log"
 	"github.com/mmp/vice/pkg/panes"
@@ -1460,7 +1462,7 @@ func uiDrawMultiControllersWindow(c *client.ControlClient, p platform.Platform) 
 			imgui.TableNextColumn()
 			imgui.Text(e.Flow)
 			imgui.TableNextColumn()
-			imgui.InputText("##"+e.Flow, &e.Controller)
+			imgui.InputTextWithHint("##"+e.Flow, "", &e.Controller, 0, nil)
 		}
 
 		imgui.EndTable()


### PR DESCRIPTION
## Summary
- support editing multi-controller flows at runtime
- expose new RPC SetMultiControllers
- add a window for adjusting multi-controller settings
- show window via toolbar users icon
- include new FontAwesome icon

## Testing
- `go test ./...` *(fails: module downloads blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685b7b939d8c832ab621dde405d75365