### PR TITLE
Fix ERAM default map loading

### DIFF
--- a/pkg/sim/state.go
+++ b/pkg/sim/state.go
@@ -288,6 +288,13 @@ func (ss *State) GetStateForController(tcp string) *State {
 		state.ControllerMonitoredBeaconCodeBlocks = ss.STARSFacilityAdaptation.MonitoredBeaconCodeBlocks
 	}
 
+	// ERAM controllers don't have entries in ControllerConfigs, so make sure
+	// they still get the scenario's default video maps.
+	if ctrl, ok := state.Controllers[tcp]; ok && ctrl.ERAMFacility {
+		state.ControllerDefaultVideoMaps = ss.ScenarioDefaultVideoMaps
+		state.ControllerVideoMaps = ss.STARSFacilityAdaptation.VideoMapNames
+	}
+
 	return &state
 }
 


### PR DESCRIPTION
## Summary
- ensure ERAM controllers receive scenario default video maps

## Testing
- `go test ./...` *(fails: downloading modules blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6862eb074890832a9c2e92069644045b